### PR TITLE
Serial control 2

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,9 +16,12 @@ Need to log: temp1, temp2, current, voltage, timestamp, fan1, fan2
   - ~~coolbox log location path~~
 - server/PiccoloCoolboxControl.py
   - ~~Add parent class to handle serial connection. Getter and setter, and init.~~
-  - Make new fan class. Then on line 114 - 116 of coolboxControl class, register the fan classes
-  - Make new voltage class. Then on line 114 - 116 of coolboxControl class, register the voltage classes
-  - Make new current class. Then on line 114 - 116 of coolboxControl class, register the current classes
+  - ~~Make new fan class.~~
+  - Then on line 114 - 116 of coolboxControl class, register the fan classes
+  - ~~Make new voltage class.~~
+  - Then on line 114 - 116 of coolboxControl class, register the voltage classes
+  - ~~Make new current class.~~
+  - Then on line 114 - 116 of coolboxControl class, register the current classes
   - Add logging code to server/PiccoloCoolBoxControl - logging code on 129.
 - Proxy classes
   - Add proxy classes for fan / voltage / current classes

--- a/TODO.md
+++ b/TODO.md
@@ -17,11 +17,11 @@ Need to log: temp1, temp2, current, voltage, timestamp, fan1, fan2
 - server/PiccoloCoolboxControl.py
   - ~~Add parent class to handle serial connection. Getter and setter, and init.~~
   - ~~Make new fan class.~~
-  - Then on line 114 - 116 of coolboxControl class, register the fan classes
+  - ~~Then on line 114 - 116 of coolboxControl class, register the fan classes~~
   - ~~Make new voltage class.~~
-  - Then on line 114 - 116 of coolboxControl class, register the voltage classes
+  - ~~Then on line 114 - 116 of coolboxControl class, register the voltage classes~~
   - ~~Make new current class.~~
-  - Then on line 114 - 116 of coolboxControl class, register the current classes
+  - ~~Then on line 114 - 116 of coolboxControl class, register the current classes~~
   - Add logging code to server/PiccoloCoolBoxControl - logging code on 129.
 - Proxy classes
   - Add proxy classes for fan / voltage / current classes

--- a/piccolo3/server/PiccoloConfig.py
+++ b/piccolo3/server/PiccoloConfig.py
@@ -59,6 +59,7 @@ defaultCfgStr = """
   [[fans]]
     [[[__many__]]]
       fan_on = boolean(deafult=False)
+      fan_on = boolean(deafult=False)
 
 [output]
   # overwrite output files when clobber is set to True

--- a/piccolo3/server/PiccoloCoolboxControl.py
+++ b/piccolo3/server/PiccoloCoolboxControl.py
@@ -32,11 +32,10 @@ import logging
 from random import randint
 
 
-class PiccoloSerialConnection(PiccoloNamedComponent):
+class PiccoloSerialConnection:
     """Manage serial connection for controlling and managing the coolbox"""
 
     def __init__(self, serial_port="/dev/ttyUSB0"):
-        super().__init__()
         self.verbose = False
         self.tsleep = 0.001
         self._serial_port = serial_port
@@ -109,12 +108,12 @@ class PiccoloSerialConnection(PiccoloNamedComponent):
                 self.log.error(e)
 
 
-class PiccoloTemperature(PiccoloSerialConnection):
+class PiccoloTemperature(PiccoloNamedComponent):
     """manage temperature control on coolbox"""
 
     NAME = "coolboxctrl"
 
-    def __init__(self, name, target=10):
+    def __init__(self, name, serial_connection, target=20):
         super().__init__(name)
 
         self._target_temp_changed = None
@@ -122,6 +121,12 @@ class PiccoloTemperature(PiccoloSerialConnection):
 
         self._current_temp_changed = None
         self._current_temp = None
+
+        self._serial_connection = serial_connection
+
+    @property
+    def serial_connection(self):
+        return self._serial_connection
 
     @property
     def target_temp(self):
@@ -132,7 +137,7 @@ class PiccoloTemperature(PiccoloSerialConnection):
         self._target_temp = temp
         # do something to the coolbox
         cmd_str = "$R0=" + str(temp) + "\r\n"
-        await self.serial_command(cmd_str)
+        await self.serial_connection.serial_command(cmd_str)
 
         if self._target_temp_changed is not None:
             self._target_temp_changed()
@@ -160,6 +165,11 @@ class PiccoloTemperature(PiccoloSerialConnection):
             if self._current_temp_changed is not None:
                 self._current_temp_changed()
 
+    async def refresh_current_temp(self):
+        cmd_str = "$RN100?\r\n"
+        current_temp = await self.serial_connection.serial_command(cmd_str)
+        self.current_temp = current_temp
+
     @piccoloGET
     def get_current_temp(self):
         return self.current_temp
@@ -169,16 +179,22 @@ class PiccoloTemperature(PiccoloSerialConnection):
         self._current_temp_changed = cb
 
 
-class PiccoloVoltage(PiccoloSerialConnection):
+class PiccoloVoltage(PiccoloNamedComponent):
     """Read voltage on coolbox"""
 
     NAME = "coolboxctrl"
 
-    def __init__(self, name):
+    def __init__(self, name, serial_connection):
         super().__init__(name)
 
         self._current_voltage = None
         self._current_voltage_changed = None
+
+        self._serial_connection = serial_connection
+
+    @property
+    def serial_connection(self):
+        return self._serial_connection
 
     @property
     def current_voltage(self):
@@ -191,6 +207,11 @@ class PiccoloVoltage(PiccoloSerialConnection):
             if self._current_voltage_changed is not None:
                 self._current_voltage_changed()
 
+    async def refresh_current_voltage(self):
+        cmd_str = "$RN151?\r\n"
+        current_voltage = await self.serial_connection.serial_command(cmd_str)
+        self.current_voltage = current_voltage
+
     @piccoloGET
     def get_current_voltage(self):
         return self.current_voltage
@@ -200,16 +221,22 @@ class PiccoloVoltage(PiccoloSerialConnection):
         self._current_voltage_changed = cb
 
 
-class PiccoloCurrent(PiccoloSerialConnection):
+class PiccoloCurrent(PiccoloNamedComponent):
     """Read current on coolbox"""
 
     NAME = "coolboxctrl"
 
-    def __init__(self, name):
+    def __init__(self, name, serial_connection):
         super().__init__(name)
 
         self._current_current = None
         self._current_current_changed = None
+
+        self._serial_connection = serial_connection
+
+   @property
+    def serial_connection(self):
+        return self._serial_connection 
 
     @property
     def current_current(self):
@@ -222,6 +249,11 @@ class PiccoloCurrent(PiccoloSerialConnection):
             if self._current_current_changed is not None:
                 self._current_current_changed()
 
+    async def refresh_current_current(self):
+        cmd_str="$RN152?\r\n"
+        current_current = await self.serial_connection.serial_command(cmd_str)
+        self.current_current = current_current
+
     @piccoloGET
     def get_current_current(self):
         return self.current_current
@@ -231,12 +263,12 @@ class PiccoloCurrent(PiccoloSerialConnection):
         self._current_current_changed = cb
 
 
-class PiccoloFan(PiccoloSerialConnection):
+class PiccoloFan(PiccoloNamedComponent):
     """manage fan control on coolbox"""
 
     NAME = "coolboxctrl"
 
-    def __init__(self, name, fan_state=10):
+    def __init__(self, name, serial_connection, fan_state=False):
         super().__init__(name)
 
         self._target_fan_state_changed = None
@@ -244,6 +276,12 @@ class PiccoloFan(PiccoloSerialConnection):
 
         self._current_fan_state_changed = None
         self._current_fan_state = None
+
+        self._serial_connection = serial_connection
+
+    @property
+    def serial_connection(self):
+        return self._serial_connection
 
     @property
     def target_fan_state(self):
@@ -257,7 +295,7 @@ class PiccoloFan(PiccoloSerialConnection):
             cmd_str = "$R16="+control+"\r\n"
         else:
             cmd_str = "$R23="+control+"\r\n"
-        await self.serial_command(cmd_str)
+        await self.serial_connection.serial_command(cmd_str)
 
         if self._target_fan_state_changed is not None:
             self._target_fan_state_changed()
@@ -303,10 +341,30 @@ class PiccoloCoolboxControl(PiccoloBaseComponent):
         super().__init__()
 
         self._update_interval = coolbox_cfg['update_interval']
+        self._serial_connection = PiccoloSerialConnection(serial_port=coolbox_cfg['serial_port'])
+        self._voltage_sensors = {"voltage": PiccoloVoltage("voltage", serial_connection=self.serial_connection)}
+        self._current_sensors = {"current": PiccoloCurrent("current",serial_connection=self.serial_connection)}
+        self._fan_sensors = {}
         self._temperature_sensors = {}
+        for fan in coolbox_cfg['fans']:
+            self._fan_sensors[temp] = PiccoloTemperature(fan,
+                                                                fan_state=coolbox_cfg['fans'][fan]['fan_on'],serial_connection=self.serial_connection)
+        
         for temp in coolbox_cfg['temperature_sensors']:
             self.temperature_sensors[temp] = PiccoloTemperature(temp,
-                                                                target=coolbox_cfg['temperature_sensors'][temp]['target'])
+                                                                target=coolbox_cfg['temperature_sensors'][temp]['target'],serial_connection=self.serial_connection) # should this be self._temperatures_sensors, as no setter? 
+
+        for volts in self.voltage_sensors:
+            self.coapResources.add_resource(
+                [volts], self.voltage_sensors[volts].coapResources)
+
+        for current in self.current_sensors:
+            self.coapResources.add_resource(
+                [current], self.current_sensors[current].coapResources)
+
+        for fan in self.temperature_sensors:
+            self.coapResources.add_resource(
+                [temp], self.temperature_sensors[temp].coapResources)
 
         for temp in self.temperature_sensors:
             self.coapResources.add_resource(
@@ -322,11 +380,23 @@ class PiccoloCoolboxControl(PiccoloBaseComponent):
 
         while True:
             # read temperature from coolbox
+            # for temp in self.temperature_sensors:
+            #     self.temperature_sensors[temp].current_temp = randint(
+            #         0, abs(self.temperature_sensors[temp].target_temp))
             for temp in self.temperature_sensors:
-                self.temperature_sensors[temp].current_temp = randint(
-                    0, abs(self.temperature_sensors[temp].target_temp))
+                await self.temperature_sensors[temp].refresh_current_temp() 
+
+            for volt in self.voltage_sensors:
+                await self.voltage_sensors[volt].refresh_current_voltage() 
+
+            for curr in self.current_sensors:
+                await self.current_sensors[curr].refresh_current_current() 
 
             await asyncio.sleep(self._update_interval)
+
+    @property
+    def serial_connection(self):
+        return self._serial_connection
 
     @property
     def temperature_sensors(self):
@@ -337,6 +407,44 @@ class PiccoloCoolboxControl(PiccoloBaseComponent):
         temp = list(self.temperature_sensors.keys())
         temp.sort()
         return temp
+
+    # Do we need setters for this here too? 
+
+    @property
+    def fan_sensors(self):
+        return self._fan_sensors
+
+    @piccoloGET
+    def get_fan_sensors(self):
+        fans = list(self.fan_sensors.keys())
+        fans.sort()
+        return fans
+
+    # Do we need setters for this here too? 
+
+    @property
+    def voltage_sensors(self):
+        return self._voltage_sensors 
+
+    @piccoloGET
+    def get_voltage_sensors(self):
+        volts = list(self.voltage_sensors.keys())
+        volts.sort()
+        return volts
+
+    # Do we need setters for this here too? 
+
+    @property
+    def current_sensors(self):
+        return self._current_sensors 
+
+    @piccoloGET
+    def get_current_sensors(self):
+        current = list(self.current_sensors.keys())
+        current.sort()
+        return current
+
+    # Do we need setters for this here too? 
 
 
 if __name__ == '__main__':

--- a/piccolo3/server/PiccoloCoolboxControl.py
+++ b/piccolo3/server/PiccoloCoolboxControl.py
@@ -348,7 +348,7 @@ class PiccoloCoolboxControl(PiccoloBaseComponent):
         self._temperature_sensors = {}
 
         for fan in coolbox_cfg['fans']:
-            self._fan_sensors[temp] = PiccoloFan(fan, serial_connection=self.serial_connection, fan_state=coolbox_cfg['fans'][fan]['fan_on'])
+            self.fan_sensors[temp] = PiccoloFan(fan, serial_connection=self.serial_connection, fan_state=coolbox_cfg['fans'][fan]['fan_on'])
         
         for temp in coolbox_cfg['temperature_sensors']:
             self.temperature_sensors[temp] = PiccoloTemperature(temp, serial_connection=self.serial_connection, target=coolbox_cfg['temperature_sensors'][temp]['target']) # should this be self._temperatures_sensors, as no setter? 
@@ -410,6 +410,10 @@ class PiccoloCoolboxControl(PiccoloBaseComponent):
     @property
     def temperature_sensors(self):
         return self._temperature_sensors
+    
+    @temperature_sensors.setter
+    def temperature_sensors(self, sensor):
+        self._temperature_sensors = sensor
 
     @piccoloGET
     def get_temperature_sensors(self):
@@ -417,19 +421,19 @@ class PiccoloCoolboxControl(PiccoloBaseComponent):
         temp.sort()
         return temp
 
-    # Do we need setters for this here too? 
-
     @property
     def fan_sensors(self):
         return self._fan_sensors
+    
+    @fan_sensors.setter
+    def temperature_sensors(self, sensor):
+        self._fan_sensors = sensor
 
     @piccoloGET
     def get_fan_sensors(self):
         fans = list(self.fan_sensors.keys())
         fans.sort()
         return fans
-
-    # Do we need setters for this here too? 
 
     @property
     def voltage_sensors(self):
@@ -441,8 +445,6 @@ class PiccoloCoolboxControl(PiccoloBaseComponent):
         volts.sort()
         return volts
 
-    # Do we need setters for this here too? 
-
     @property
     def current_sensors(self):
         return self._current_sensors 
@@ -453,7 +455,6 @@ class PiccoloCoolboxControl(PiccoloBaseComponent):
         current.sort()
         return current
 
-    # Do we need setters for this here too? 
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Main headlines:** have made 3 extra classes to hold current, voltage and fan sensors. 

**Questions**

1. I've created one serial connection class and am handing it into each sensor class. I think this is the only way that the lock will work to stop different classes opening and closing the serial port. Is this a good idea? 
2. On what is now line 353 you've got self.temperatures_sensors... . I'm not sure if this is a typo and should be accessing the private var self._temper..., or if it works fine as it is as via some other python mechanism I don't know. 